### PR TITLE
Compile prebuilt binaries using musl target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
             archive: tgz
@@ -27,7 +27,7 @@ jobs:
             os: macos-latest
             output: cargo-binstall
             archive: zip
-          - target: armv7-unknown-linux-gnueabihf
+          - target: armv7-unknown-linux-musleabihf
             os: ubuntu-20.04
             output: cargo-binstall
             archive: tgz
@@ -48,7 +48,7 @@ jobs:
         override: true
  
     - name: Install openssl (apt armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       uses: ryankurte/action-apt@v0.3.0
       with:
         arch: armhf
@@ -65,14 +65,22 @@ jobs:
           target
 
     - name: Install cross toolchain (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
-      run: sudo apt install gcc-arm-linux-gnueabihf
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      run: sudo apt install gcc-arm-linux-musleabihf
 
     - name: Enable cross compilation (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: |
         echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
         echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
+
+    - name: Install musl-tools
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      run: sudo apt-get install -y musl-tools
+
+    - name: Install musl-tools
+      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      run: sudo apt-get install -y musl-tools
 
     - name: Build release
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
So that it is statically linked and does not depend on any dynamic
library and can be run anywhere.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>